### PR TITLE
Use one goroutine per log event sent

### DIFF
--- a/backend/api/users/main.go
+++ b/backend/api/users/main.go
@@ -23,6 +23,13 @@ func (request *userRequest) init() {
 }
 
 func (request *userRequest) finish() {
+	defer func() {
+		err := request.log.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
 	request.log.LogLambdaTime(request.startingTime, request.err, recover())
 }
 


### PR DESCRIPTION
Why: Prevent multiple channel/goroutines data races