### PR TITLE
[frontend] Add "staleTime" to get user query in Navbar

### DIFF
--- a/frontend/src/components/molecules/Navbar.tsx
+++ b/frontend/src/components/molecules/Navbar.tsx
@@ -54,6 +54,7 @@ export function Navbar({ children }: NavbarProps) {
     queryKey: ["user"],
     queryFn: () => api.getUser(),
     retry: false,
+    staleTime: 1000,
     refetchOnWindowFocus: false,
   });
 


### PR DESCRIPTION
Why: The getUser query was being executed twice, in Navbar and Home. Probably because as both components were mounted at the same time, there was no cache existing by the time the Navbar was mounted.