### PR TITLE
[frontend] Modify "gray" color palette

### DIFF
--- a/frontend/src/assets/styles.ts
+++ b/frontend/src/assets/styles.ts
@@ -1,46 +1,46 @@
-import {createTheme, Theme} from "@mui/material";
-import {Colors} from "./index.ts";
+import { createTheme, Theme } from "@mui/material";
+import { Colors } from "./index.ts";
 
 export const theme: Theme = createTheme({
-    typography: {
-        fontFamily: ["Outfit", "sans-serif"].join(","),
+  typography: {
+    fontFamily: ["Outfit", "sans-serif"].join(","),
+  },
+  palette: {
+    primary: {
+      main: Colors.GREEN,
+      darker: Colors.GREEN_DARK,
     },
-    palette: {
-        primary: {
-            main: Colors.GREEN,
-            darker: Colors.GREEN_DARK,
-        },
-        secondary: {
-            main: Colors.ORANGE,
-            contrastText: Colors.WHITE,
-        },
-        white: {
-            main: Colors.WHITE,
-            dark: Colors.WHITE_DARK,
-            darker: Colors.WHITE_DARKER,
-        },
-        red: {
-            main: Colors.RED,
-            dark: Colors.RED_DARK,
-            darker: Colors.RED_DARKER,
-        },
-        blue: {
-            main: Colors.BLUE,
-            dark: Colors.BLUE_DARK,
-            darker: Colors.BLUE_DARKER,
-        },
-        gray: {
-            // Use this color as it is the same as the "bg-zinc-100" Tailwind class
-            main: Colors.GRAY,
-            dark: Colors.GRAY_DARK,
-            darker: Colors.GRAY_DARKER,
-            light: Colors.GRAY_LIGHT,
-        },
-        darkGreen: {
-            main: Colors.GREEN_DARK,
-        },
-        darkerGray: {
-            main: Colors.GRAY_DARKER,
-        },
+    secondary: {
+      main: Colors.ORANGE,
+      contrastText: Colors.WHITE,
     },
+    white: {
+      main: Colors.WHITE,
+      dark: Colors.WHITE_DARK,
+      darker: Colors.WHITE_DARKER,
+    },
+    red: {
+      main: Colors.RED,
+      dark: Colors.RED_DARK,
+      darker: Colors.RED_DARKER,
+    },
+    blue: {
+      main: Colors.BLUE,
+      dark: Colors.BLUE_DARK,
+      darker: Colors.BLUE_DARKER,
+    },
+    gray: {
+      main: "#bdbdbd",
+      dark: "#9e9e9e",
+      contrastText: Colors.WHITE,
+      darker: Colors.GRAY_DARKER,
+      light: Colors.GRAY_LIGHT,
+    },
+    darkGreen: {
+      main: Colors.GREEN_DARK,
+    },
+    darkerGray: {
+      main: Colors.GRAY_DARKER,
+    },
+  },
 });

--- a/frontend/src/components/organisms/ExpensesTable.tsx
+++ b/frontend/src/components/organisms/ExpensesTable.tsx
@@ -16,7 +16,7 @@ import { CategorySelect } from "./CategorySelect.tsx";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { useGetExpenses } from "../../queries";
 import { ErrorSnackbar, Table } from "../molecules";
-import { utils } from "../../utils/index.ts";
+import {tableDateFormatter} from "../../utils";
 
 type ExpensesTableProps = {
   categories: Category[] | undefined;
@@ -80,7 +80,7 @@ export function ExpensesTable({ categories, period }: ExpensesTableProps) {
       field: "created_date",
       headerName: "Date",
       width: 200,
-      valueFormatter: (params) => utils.tableDateFormatter.format(params),
+      valueFormatter: (params) => tableDateFormatter.format(params),
     },
   ];
 

--- a/frontend/src/pages/IncomeTable.tsx
+++ b/frontend/src/pages/IncomeTable.tsx
@@ -19,6 +19,7 @@ import { useRef, useState } from "react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { GridValidRowModel } from "@mui/x-data-grid/models/gridRows";
 import { v4 as uuidv4 } from "uuid";
+import { tableDateFormatter } from "../utils";
 
 export function IncomeTable() {
   const gridStyle = {
@@ -73,14 +74,7 @@ export function IncomeTable() {
       headerName: "Date",
       width: 200,
       valueFormatter: (params) => {
-        return new Intl.DateTimeFormat("en-GB", {
-          weekday: "short",
-          year: "numeric",
-          month: "numeric",
-          day: "numeric",
-          hour: "numeric",
-          minute: "numeric",
-        }).format(params);
+        return tableDateFormatter.format(params);
       },
     },
   ];


### PR DESCRIPTION
Why: The previous "main" and "dark" variations were too bright and too dark. This also meant that a different contrast text was needed for each
 shaed(black and white), and MUI doesn't support this.